### PR TITLE
Add TrayIcon

### DIFF
--- a/src/AudioBand/AudioBand.csproj
+++ b/src/AudioBand/AudioBand.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Commands\AsyncRelayCommand.cs" />
     <Compile Include="Settings\Migrations\IdentitySettingsMigrator.cs" />
     <Compile Include="Settings\Persistence\TomlHelper.cs" />
+    <Compile Include="UI\TrayIconService.cs" />
     <Compile Include="UI\ValueConverters\ValueConverterHelper.cs" />
     <Compile Include="UI\ViewModel\TrackStateAttribute.cs" />
     <Compile Include="Commands\AsyncRelayCommand{T}.cs" />
@@ -531,6 +532,9 @@
     </PackageReference>
     <PackageReference Include="FluentWPF">
       <Version>0.6.1</Version>
+    </PackageReference>
+    <PackageReference Include="Hardcodet.NotifyIcon.Wpf">
+      <Version>1.1.0</Version>
     </PackageReference>
     <PackageReference Include="MahApps.Metro">
       <Version>1.6.5</Version>

--- a/src/AudioBand/Deskband.cs
+++ b/src/AudioBand/Deskband.cs
@@ -117,6 +117,7 @@ namespace AudioBand
                 _container.Register<IPersistentSettings, PersistentSettings>(Lifestyle.Singleton);
                 _container.Register<GitHubHelper>(Lifestyle.Singleton);
                 _container.Register<PopupService>(Lifestyle.Singleton);
+                _container.Register<TrayIconService>(Lifestyle.Singleton);
 
                 _container.Register<AboutDialogViewModel>(Lifestyle.Singleton);
                 _container.Register<AlbumArtViewModel>(Lifestyle.Singleton);

--- a/src/AudioBand/UI/TrayIconService.cs
+++ b/src/AudioBand/UI/TrayIconService.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using Hardcodet.Wpf.TaskbarNotification;
+
+namespace AudioBand.UI
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class TrayIconService
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TrayIconService"/> class.
+        /// </summary>
+        public TrayIconService()
+        {
+            TaskbarIconToolTip = new ToolTip() { Content = "AudioBand" };
+
+            TaskbarIcon = new TaskbarIcon()
+            {
+                TrayToolTip = TaskbarIconToolTip,
+            };
+        }
+
+        /// <summary>
+        /// Finalizes an instance of the <see cref="TrayIconService"/> class.
+        /// </summary>
+        ~TrayIconService()
+        {
+            TaskbarIcon.Dispose();
+        }
+
+        /// <summary>
+        /// Gets the current TaskbarIcon.
+        /// </summary>
+        public TaskbarIcon TaskbarIcon { get; private set; }
+
+        /// <summary>
+        /// Gets the current ContextMenu used in the Taskbar
+        /// </summary>
+        public ContextMenu TaskbarIconContextMenu { get; private set; }
+
+        /// <summary>
+        /// Gets the current ToolTip used in the Taskbar.
+        /// </summary>
+        public ToolTip TaskbarIconToolTip { get; private set; }
+    }
+}


### PR DESCRIPTION
## Summary
This summary adds a TrayIcon to Windows's tray (bottom right).
The ultimate goal of this icon is to have the ability to open up audioband from within, so the app even becomes available on Windows 11 without patching the taskbar.

I would also like to have customizability in it, for example people can choose what options you have on right click.
Open Settings would be the only permanent one you can't adjust.

## Checklist
- [ ] Implement basic tray icon with a simple settings menu
- [ ] Nicely theme the context menu
- [ ] Implement customizability to allow for song skipping/pausing/etc in right click menu
- [ ] Ultimately implement left click menu to open a window with audioband in it