### PR TITLE
Implement Customizable MouseBindings

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# SA1413: Use trailing comma in multi-line initializers
+dotnet_diagnostic.SA1413.severity = silent

--- a/src/AudioBand.AudioSource/AudioBand.AudioSource.csproj
+++ b/src/AudioBand.AudioSource/AudioBand.AudioSource.csproj
@@ -110,5 +110,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="..\.editorconfig">
+      <Link>.editorconfig</Link>
+    </None>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/AudioBand.sln
+++ b/src/AudioBand.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.156
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32319.34
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AudioBand", "AudioBand\AudioBand.csproj", "{B69832AD-8373-47AC-A52A-183238903896}"
 EndProject
@@ -28,6 +28,11 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{E79F26F3-C51F-4375-BF1C-4090FAB8D16D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Win10AudioSource", "Win10AudioSource\Win10AudioSource.csproj", "{A709B842-7F5A-4C81-8A2E-80396996EF79}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9EE333F0-8D6F-4D2B-A0E8-05AE7A9D6961}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/AudioBand/AudioBand.csproj
+++ b/src/AudioBand/AudioBand.csproj
@@ -107,7 +107,7 @@
     <Compile Include="AudioSource\IAudioSession.cs" />
     <Compile Include="AudioSource\IAudioSourceManager.cs" />
     <Compile Include="AudioSource\IInternalAudioSource.cs" />
-    <Compile Include="Models\MousBinding.cs" />
+    <Compile Include="Models\MouseBinding.cs" />
     <Compile Include="Models\MouseBindingCommandType.cs" />
     <Compile Include="Models\MouseInputType.cs" />
     <Compile Include="Models\UserProfile.cs" />

--- a/src/AudioBand/AudioBand.csproj
+++ b/src/AudioBand/AudioBand.csproj
@@ -107,6 +107,9 @@
     <Compile Include="AudioSource\IAudioSession.cs" />
     <Compile Include="AudioSource\IAudioSourceManager.cs" />
     <Compile Include="AudioSource\IInternalAudioSource.cs" />
+    <Compile Include="Models\MousBinding.cs" />
+    <Compile Include="Models\MouseBindingCommandType.cs" />
+    <Compile Include="Models\MouseInputType.cs" />
     <Compile Include="Models\UserProfile.cs" />
     <Compile Include="Models\SemanticVersion.cs" />
     <Compile Include="Settings\MappingProfiles\SettingsV1ToSettingsV2Profile.cs" />
@@ -130,6 +133,7 @@
     <Compile Include="Commands\AsyncRelayCommand.cs" />
     <Compile Include="Settings\Migrations\IdentitySettingsMigrator.cs" />
     <Compile Include="Settings\Persistence\TomlHelper.cs" />
+    <Compile Include="UI\Toolbar\MouseBindingsViewModel.cs" />
     <Compile Include="UI\ValueConverters\ValueConverterHelper.cs" />
     <Compile Include="UI\ViewModel\TrackStateAttribute.cs" />
     <Compile Include="Commands\AsyncRelayCommand{T}.cs" />
@@ -465,6 +469,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="UI\PlaybackControls\PlayPauseButtonSettingsView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="UI\Toolbar\MouseBindingsView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/AudioBand/Deskband.cs
+++ b/src/AudioBand/Deskband.cs
@@ -122,6 +122,7 @@ namespace AudioBand
                 _container.Register<AlbumArtViewModel>(Lifestyle.Singleton);
                 _container.Register<AlbumArtPopupViewModel>(Lifestyle.Singleton);
                 _container.Register<GlobalSettingsViewModel>(Lifestyle.Singleton);
+                _container.Register<MouseBindingsViewModel>(Lifestyle.Singleton);
                 _container.Register<GeneralSettingsViewModel>(Lifestyle.Singleton);
                 _container.Register<CustomLabelsViewModel>(Lifestyle.Singleton);
                 _container.Register<NextButtonViewModel>(Lifestyle.Singleton);

--- a/src/AudioBand/Models/AudioBandSettings.cs
+++ b/src/AudioBand/Models/AudioBandSettings.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+using System.Collections.Generic;
 
 namespace AudioBand.Models
 {
@@ -10,7 +10,7 @@ namespace AudioBand.Models
         private string _lastNonIdleProfileName = "";
 
         /// <summary>
-        /// Gets the last active profile name before going into idle.
+        /// Gets or sets the last active profile name before going into idle.
         /// </summary>
         public string LastNonIdleProfileName
         {
@@ -33,17 +33,17 @@ namespace AudioBand.Models
         public string LastKnownVersion { get; set; } = "v0.0.0";
 
         /// <summary>
-        /// The profile that should enable when AudioBand goes into idle mode.
+        /// Gets or sets he profile that should enable when AudioBand goes into idle mode.
         /// </summary>
         public string IdleProfileName { get; set; } = "Idle";
 
         /// <summary>
-        /// Gets or sets whether to use the Idle Profile.
+        /// Gets or sets a value indicating whether to use the Idle Profile.
         /// </summary>
         public bool UseAutomaticIdleProfile { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets whether to hide the Idle profile in the Profiles quick menu.
+        /// Gets or sets a value indicating whether to hide the Idle profile in the Profiles quick menu.
         /// </summary>
         public bool HideIdleProfileInQuickMenu { get; set; } = true;
 
@@ -53,23 +53,28 @@ namespace AudioBand.Models
         public int ShouldGoIdleAfterInSeconds { get; set; } = 300;
 
         /// <summary>
-        /// Gets or sets whether to clear the current session information when it goes into idle.
+        /// Gets or sets a value indicating whether to clear the current session information when it goes into idle.
         /// </summary>
         public bool ClearSessionOnIdle { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets whether to show a popup when an update is available.
+        /// Gets or sets a value indicating whether to show a popup when an update is available.
         /// </summary>
         public bool ShowPopupOnAvailableUpdate { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets whether to show little help popups when something fails.
+        /// Gets or sets a value indicating whether to show little help popups when something fails.
         /// </summary>
         public bool ShowInformationPopups { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets whether to opt-in for pre-releases.
+        /// Gets or sets a value indicating whether to opt-in for pre-releases.
         /// </summary>
         public bool OptInForPreReleases { get; set; }
+
+        /// <summary>
+        /// Gets or sets the mouse bindings.
+        /// </summary>
+        public List<MouseBinding> MouseBindings { get; set; } = new List<MouseBinding>();
     }
 }

--- a/src/AudioBand/Models/MousBinding.cs
+++ b/src/AudioBand/Models/MousBinding.cs
@@ -1,0 +1,33 @@
+﻿namespace AudioBand.Models
+{
+    /// <summary>
+    /// Represents a configurable MouseBinding.
+    /// </summary>
+    public class MousBinding
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to use ctrl with this bind.
+        /// </summary>
+        public bool WithCtrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use shift with this bind.
+        /// </summary>
+        public bool WithShift { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use shift with this bind.
+        /// </summary>
+        public bool WithAlt { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use xxx with this bind.
+        /// </summary>
+        public bool WithPower { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of mouse behaviour associated with this mouse binding.
+        /// </summary>
+        public MouseInputType MouseInputType { get; set; }
+    }
+}

--- a/src/AudioBand/Models/MouseBinding.cs
+++ b/src/AudioBand/Models/MouseBinding.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Represents a configurable MouseBinding.
     /// </summary>
-    public class MousBinding
+    public class MouseBinding
     {
         /// <summary>
         /// Gets or sets a value indicating whether to use ctrl with this bind.
@@ -29,5 +29,10 @@
         /// Gets or sets the type of mouse behaviour associated with this mouse binding.
         /// </summary>
         public MouseInputType MouseInputType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of command to execute.
+        /// </summary>
+        public MouseBindingCommandType CommandType { get; set; }
     }
 }

--- a/src/AudioBand/Models/MouseBindingCommandType.cs
+++ b/src/AudioBand/Models/MouseBindingCommandType.cs
@@ -1,0 +1,68 @@
+﻿namespace AudioBand.Models
+{
+    /// <summary>
+    /// The command type related to the mouse binding.
+    /// </summary>
+    public enum MouseBindingCommandType
+    {
+        /// <summary>
+        /// Switches to the next profile.
+        /// </summary>
+        NextProfile = 0,
+
+        /// <summary>
+        /// Switches to the previous profile.
+        /// </summary>
+        PreviousProfile = 1,
+
+        /// <summary>
+        /// Plays/Resumes whatever is playing.
+        /// </summary>
+        Play = 2,
+
+        /// <summary>
+        /// Pauses whatever is playing.
+        /// </summary>
+        Pause = 3,
+
+        /// <summary>
+        /// Switches to the next song.
+        /// </summary>
+        NextSong = 4,
+
+        /// <summary>
+        /// Switches to the previous song.
+        /// </summary>
+        PreviousSong = 5,
+
+        /// <summary>
+        /// Switches to the next repeat mode.
+        /// </summary>
+        NextRepeatMode = 6,
+
+        /// <summary>
+        /// Switches to the previous repeat mode.
+        /// </summary>
+        PreviousRepeatMode = 7,
+
+        /// <summary>
+        /// Toggles shuffle mode.
+        /// </summary>
+        ToggleShuffleMode = 8,
+
+        /// <summary>
+        /// Puts the volume higher.
+        /// </summary>
+        VolumeHigher = 9,
+
+        /// <summary>
+        /// Puts the volume lower.
+        /// </summary>
+        VolumeLower = 10,
+
+        /// <summary>
+        /// Opens the associated music app if possible.
+        /// </summary>
+        OpenAssociatedApp = 11
+    }
+}

--- a/src/AudioBand/Models/MouseInputType.cs
+++ b/src/AudioBand/Models/MouseInputType.cs
@@ -1,0 +1,38 @@
+﻿namespace AudioBand.Models
+{
+    /// <summary>
+    /// The mouse input type related to a MouseBinding.
+    /// </summary>
+    public enum MouseInputType
+    {
+        /// <summary>
+        /// Left mouse click.
+        /// </summary>
+        LeftClick = 0,
+
+        /// <summary>
+        /// Double left mouse click.
+        /// </summary>
+        LeftDoubleClick = 1,
+
+        /// <summary>
+        /// Middle mouse click.
+        /// </summary>
+        MiddleClick = 2,
+
+        /// <summary>
+        /// Double middle mouse click.
+        /// </summary>
+        MiddleDoubleClick = 3,
+
+        /// <summary>
+        /// Scrolling up.
+        /// </summary>
+        ScrollUp = 4,
+
+        /// <summary>
+        /// Scrolling down.
+        /// </summary>
+        ScrollDown = 5,
+    }
+}

--- a/src/AudioBand/Settings/AppSettings.cs
+++ b/src/AudioBand/Settings/AppSettings.cs
@@ -28,7 +28,9 @@ namespace AudioBand.Settings
             _persistSettings = persistSettings;
             _messageBus = messageBus;
             _persistSettings.CheckAndConvertOldSettings();
+
             var settings = _persistSettings.ReadSettings();
+            DoSettingsNullChecks(settings);
 
             AudioSource = settings.CurrentAudioSource;
             AudioSourceSettings = settings.AudioSourceSettings?.ToList() ?? new List<AudioSourceSettings>();
@@ -214,7 +216,7 @@ namespace AudioBand.Settings
                 profiles[Array.IndexOf(profiles, defaultProfile)] = UserProfile.CreateDefaultProfile(UserProfile.DefaultProfileName);
             }
 
-            DoNullChecks(ref profiles);
+            DoProfileNullChecks(ref profiles);
             _profiles = profiles.ToDictionary(profile => profile.Name, profile => profile);
 
             if (settings.CurrentProfileName == null || !_profiles.ContainsKey(settings.CurrentProfileName))
@@ -223,7 +225,32 @@ namespace AudioBand.Settings
             }
         }
 
-        private void DoNullChecks(ref UserProfile[] profiles)
+        private void DoSettingsNullChecks(Persistence.Settings settings)
+        {
+            if (settings.AudioBandSettings.MouseBindings == null || settings.AudioBandSettings.MouseBindings.Count == 0)
+            {
+                settings.AudioBandSettings.MouseBindings = new List<MouseBinding>()
+                {
+                    new MouseBinding()
+                    {
+                        MouseInputType = MouseInputType.LeftDoubleClick,
+                        CommandType = MouseBindingCommandType.OpenAssociatedApp
+                    },
+                    new MouseBinding()
+                    {
+                        MouseInputType = MouseInputType.ScrollUp,
+                        CommandType = MouseBindingCommandType.PreviousSong
+                    },
+                    new MouseBinding()
+                    {
+                        MouseInputType = MouseInputType.ScrollDown,
+                        CommandType = MouseBindingCommandType.NextSong
+                    },
+                };
+            }
+        }
+
+        private void DoProfileNullChecks(ref UserProfile[] profiles)
         {
             for (int i = 0; i < profiles.Length; i++)
             {

--- a/src/AudioBand/UI/Resources/Strings.xaml
+++ b/src/AudioBand/UI/Resources/Strings.xaml
@@ -120,6 +120,7 @@ Using style and color : {*artist:#a9a9a9}</sys:String>
 
     <!--  Navigation pane  -->
     <sys:String x:Key="GlobalSettingsTab">AudioBand Settings</sys:String>
+    <sys:String x:Key="MouseBindingsTab">Custom Mouse Bindings</sys:String>
     <sys:String x:Key="UpdaterTab">AudioBand Updates</sys:String>
     <sys:String x:Key="ProfilesTab">Profile Settings</sys:String>
     <sys:String x:Key="GeneralSettingsTab">General</sys:String>

--- a/src/AudioBand/UI/Toolbar/AudioBandToolbar.xaml
+++ b/src/AudioBand/UI/Toolbar/AudioBandToolbar.xaml
@@ -15,7 +15,8 @@
              d:DesignHeight="450"
              d:DesignWidth="800"
              Background="{Binding ViewModels.GeneralSettingsViewModel.BackgroundColor, Converter={x:Static audioband:Converters.ColorToBrush}}"
-             mc:Ignorable="d">
+             mc:Ignorable="d"
+             MouseWheel="UserControl_MouseWheel">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -70,6 +71,12 @@
             <PopupAnimation x:Key="{x:Static SystemParameters.ToolTipPopupAnimationKey}">Slide</PopupAnimation>
         </ResourceDictionary>
     </UserControl.Resources>
+    <UserControl.InputBindings>
+        <MouseBinding Gesture="LeftClick" Command="{Binding ViewModels.MouseBindingsViewModel.LeftClickCommand}" />
+        <MouseBinding Gesture="LeftDoubleClick" Command="{Binding ViewModels.MouseBindingsViewModel.DoubleLeftClickCommand}" />
+        <MouseBinding Gesture="MiddleClick" Command="{Binding ViewModels.MouseBindingsViewModel.MiddleClickCommand}" />
+        <MouseBinding Gesture="MiddleDoubleClick" Command="{Binding ViewModels.MouseBindingsViewModel.DoubleMiddleClickCommand}" />
+    </UserControl.InputBindings>
     <i:Interaction.Triggers>
         <i:EventTrigger EventName="Loaded">
             <i:InvokeCommandAction Command="{Binding LoadCommand}" />
@@ -165,10 +172,6 @@
         <Canvas.RenderTransform>
             <RotateTransform CenterX="0" CenterY="0" Angle="0" />
         </Canvas.RenderTransform>
-        <Canvas.InputBindings>
-            <MouseBinding MouseAction="LeftDoubleClick"
-                          Command="{Binding DoubleClickCommand}" />
-        </Canvas.InputBindings>
         <Canvas.Resources>
             <audioband:BindingProxy x:Key="DataContextProxy" Value="{Binding .}" />
         </Canvas.Resources>

--- a/src/AudioBand/UI/Toolbar/AudioBandToolbar.xaml.cs
+++ b/src/AudioBand/UI/Toolbar/AudioBandToolbar.xaml.cs
@@ -42,5 +42,10 @@ namespace AudioBand.UI
         {
             _viewModel.ViewModels.VolumeButtonViewModel.VolumeMouseScrollCommand.Execute(e);
         }
+
+        private void UserControl_MouseWheel(object sender, MouseWheelEventArgs e)
+        {
+            _viewModel.ViewModels.MouseBindingsViewModel.MouseWheelCommand.Execute(e);
+        }
     }
 }

--- a/src/AudioBand/UI/Toolbar/AudioBandToolbarViewModel.cs
+++ b/src/AudioBand/UI/Toolbar/AudioBandToolbarViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -11,7 +10,6 @@ using AudioBand.Messages;
 using AudioBand.Models;
 using AudioBand.Settings;
 using NLog;
-using Windows.UI.Xaml;
 
 namespace AudioBand.UI
 {
@@ -54,7 +52,6 @@ namespace AudioBand.UI
 
             ShowSettingsWindowCommand = new RelayCommand(ShowSettingsWindowCommandOnExecute);
             LoadCommand = new AsyncRelayCommand<object>(LoadCommandOnExecute);
-            DoubleClickCommand = new RelayCommand<RoutedEventArgs>(OnDoubleClick);
             SelectAudioSourceCommand = new AsyncRelayCommand<IInternalAudioSource>(SelectAudioSourceCommandOnExecute);
             SelectProfileCommand = new RelayCommand<string>(SelectProfileCommandOnExecute);
         }
@@ -83,11 +80,6 @@ namespace AudioBand.UI
         /// Gets the command to initialize loading.
         /// </summary>
         public ICommand LoadCommand { get; }
-
-        /// <summary>
-        /// Gets the command to handle double clicks.
-        /// </summary>
-        public ICommand DoubleClickCommand { get; }
 
         /// <summary>
         /// Gets the command to select an audio source.
@@ -179,39 +171,6 @@ namespace AudioBand.UI
                 : new ObservableCollection<UserProfile>(_appSettings.Profiles);
 
             RaisePropertyChanged(nameof(Profiles));
-        }
-
-        private void OnDoubleClick(RoutedEventArgs e)
-        {
-            if (SelectedAudioSource == null)
-            {
-                return;
-            }
-
-            var windowPtr = NativeMethods.FindWindow(SelectedAudioSource.WindowClassName, null);
-
-            // Spotify has some weird shenanigans with their windows, doing it like normal
-            // results in the wrong window handle being returned.
-            if (SelectedAudioSource.Name == "Spotify")
-            {
-                var spotifyProcesses = Process.GetProcessesByName("spotify");
-                var title = spotifyProcesses.FirstOrDefault(x => !string.IsNullOrEmpty(x.MainWindowTitle))?.MainWindowTitle;
-                windowPtr = NativeMethods.FindWindow(null, title);
-            }
-
-            if (windowPtr == IntPtr.Zero)
-            {
-                Logger.Warn("Could not find the associated window to open with double click.");
-            }
-            else
-            {
-                if (NativeMethods.IsIconic(windowPtr))
-                {
-                    NativeMethods.ShowWindow(windowPtr, 9);
-                }
-
-                NativeMethods.SetForegroundWindow(windowPtr);
-            }
         }
 
         private async Task SelectAudioSourceCommandOnExecute(IInternalAudioSource audioSource)

--- a/src/AudioBand/UI/Toolbar/MouseBindingsView.xaml
+++ b/src/AudioBand/UI/Toolbar/MouseBindingsView.xaml
@@ -1,5 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:audioband="clr-namespace:AudioBand.UI"
+                    xmlns:metro="http://metro.mahapps.com/winfx/xaml/controls"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <DataTemplate DataType="{x:Type audioband:MouseBindingsViewModel}">
         <DataTemplate.Resources>
@@ -12,7 +13,51 @@
             </ResourceDictionary>
         </DataTemplate.Resources>
         <StackPanel Style="{StaticResource SettingsStackPanel}">
-            <TextBlock Text="Mouse Bindings" />
+            <TextBlock Text="Styling this feature takes a lot of time, and a settings revamp is planned which would cancel out all the work." Margin="0,10,0,0" />
+            <TextBlock Text="That being said, I will keep this (ugly, non themed) editor here until the settings revamp. Sorry." />
+            <TextBlock Margin="0,7,0,0" Text="To delete an item, select a row and press the delete button." />
+            <TextBlock Text="To add an item, double click the most bottom row and start editing it." />
+            <Button Margin="0,20,0,10" Content="Start Edit" Command="{Binding StartEditCommand}" Width="80" HorizontalAlignment="Left"
+                    IsEnabled="{Binding IsEditing, Converter={x:Static audioband:Converters.InverseBool}}" />
+            <DataGrid x:Name="DataGrid" Focusable="False" AutoGenerateColumns="True"
+                      ItemsSource="{Binding Path=MouseBindings, Mode=TwoWay}"
+                      IsReadOnly="{Binding IsEditing, Converter={x:Static audioband:Converters.InverseBool}}" >
+                <!-- This ItemTemplate has no effect, but I keep the original code here in case I need it sometime later -->
+                <DataGrid.ItemTemplate>
+                    <DataTemplate>
+                        <Border BorderThickness="3" BorderBrush="{audioband:ThemeResource SystemAccentColor}"
+                                Background="Transparent" CornerRadius="5">
+                            <StackPanel Orientation="Horizontal" Margin="5" Style="{StaticResource SettingsStackPanel}">
+                                <ComboBox ItemTemplate="{StaticResource EnumDescriptorItemTemplate}"
+                                          ItemsSource="{Binding ElementName=MouseBindings, Path=DataContext.MouseInputTypes}"
+                                          SelectedItem="{Binding MouseInputType}"
+                                          SelectedValuePath="Value"
+                                          MaxWidth="150" Margin="0,0,10,0" />
+                                <ComboBox ItemTemplate="{StaticResource EnumDescriptorItemTemplate}"
+                                          ItemsSource="{Binding ElementName=MouseBindings, Path=DataContext.CommandTypes}"
+                                          SelectedItem="{Binding MouseInputType}"
+                                          MaxWidth="150" Margin="0" />
+                                <StackPanel Orientation="Vertical" Margin="20, 0, 0, 0">
+                                    <TextBlock Text="Ctrl" Style="{StaticResource DescriptionTextBlock}" Margin="0"/>
+                                    <metro:ToggleSwitch Content="{Binding WithCtrl}" />
+                                </StackPanel>
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <TextBlock Text="Shift" Style="{StaticResource DescriptionTextBlock}" Margin="0"/>
+                                    <metro:ToggleSwitch Content="{Binding WithShift}"/>
+                                </StackPanel>
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <TextBlock Text="Alt" Style="{StaticResource DescriptionTextBlock}" Margin="0"/>
+                                    <metro:ToggleSwitch Content="{Binding WithAlt}"/>
+                                </StackPanel>
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <TextBlock Text="Windows" Style="{StaticResource DescriptionTextBlock}" Margin="0"/>
+                                    <metro:ToggleSwitch Content="{Binding WithPower}"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+                </DataGrid.ItemTemplate>
+            </DataGrid>
         </StackPanel>
     </DataTemplate>
 </ResourceDictionary>

--- a/src/AudioBand/UI/Toolbar/MouseBindingsView.xaml
+++ b/src/AudioBand/UI/Toolbar/MouseBindingsView.xaml
@@ -1,0 +1,18 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:audioband="clr-namespace:AudioBand.UI"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <DataTemplate DataType="{x:Type audioband:MouseBindingsViewModel}">
+        <DataTemplate.Resources>
+            <ResourceDictionary>
+                <ResourceDictionary.MergedDictionaries>
+                    <audioband:SharedDictionary Source="../Resources/Shared.xaml" />
+                    <audioband:SharedDictionary Source="../Resources/Strings.xaml" />
+                    <audioband:SharedDictionary Source="../Resources/SettingsWindowStyle.xaml" />
+                </ResourceDictionary.MergedDictionaries>
+            </ResourceDictionary>
+        </DataTemplate.Resources>
+        <StackPanel Style="{StaticResource SettingsStackPanel}">
+            <TextBlock Text="Mouse Bindings" />
+        </StackPanel>
+    </DataTemplate>
+</ResourceDictionary>

--- a/src/AudioBand/UI/Toolbar/MouseBindingsViewModel.cs
+++ b/src/AudioBand/UI/Toolbar/MouseBindingsViewModel.cs
@@ -1,0 +1,180 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using AudioBand.AudioSource;
+using AudioBand.Commands;
+using AudioBand.Models;
+using AudioBand.Settings;
+
+namespace AudioBand.UI
+{
+    /// <summary>
+    /// The Mouse Binding ViewModel.
+    /// </summary>
+    public class MouseBindingsViewModel : ViewModelBase
+    {
+        private IAppSettings _appSettings;
+        private IAudioSession _audioSession;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MouseBindingsViewModel"/> class.
+        /// </summary>
+        /// <param name="appSettings">The app settings.</param>
+        /// <param name="audioSession">The audio session.</param>
+        public MouseBindingsViewModel(IAppSettings appSettings, IAudioSession audioSession)
+        {
+            _appSettings = appSettings;
+            _audioSession = audioSession;
+
+            LeftClickCommand = new RelayCommand(LeftClickCommandOnExecute);
+            DoubleLeftClickCommand = new RelayCommand(DoubleLeftClickCommandOnExecute);
+            MiddleClickCommand = new RelayCommand(MiddleClickCommandOnExecute);
+            DoubleMiddleClickCommand = new RelayCommand(DoubleMiddleClickCommandOnExecute);
+            MouseWheelCommand = new RelayCommand<MouseWheelEventArgs>(MouseWheelCommandOnExecute);
+        }
+
+        /// <summary>
+        /// Gets the command to handle left clicks.
+        /// </summary>
+        public ICommand LeftClickCommand { get; }
+
+        /// <summary>
+        /// Gets the command to handle double left clicks.
+        /// </summary>
+        public ICommand DoubleLeftClickCommand { get; }
+
+        /// <summary>
+        /// Gets the command to handle middle clicks.
+        /// </summary>
+        public ICommand MiddleClickCommand { get; }
+
+        /// <summary>
+        /// Gets the command to handle double middle clicks.
+        /// </summary>
+        public ICommand DoubleMiddleClickCommand { get; }
+
+        /// <summary>
+        /// Gets the command to handle mouse scrolling.
+        /// </summary>
+        public ICommand MouseWheelCommand { get; }
+
+        private void LeftClickCommandOnExecute()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void DoubleLeftClickCommandOnExecute()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void MiddleClickCommandOnExecute()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void DoubleMiddleClickCommandOnExecute()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void MouseWheelCommandOnExecute(MouseWheelEventArgs args)
+        {
+            if (args.Delta > 0)
+            {
+                // next
+                return;
+            }
+
+            // previous
+        }
+
+        private void ExecuteCommandBasedOnInputType(MouseBindingCommandType inputType)
+        {
+            switch (inputType)
+            {
+                case MouseBindingCommandType.NextProfile:
+                    SwitchProfile();
+                    break;
+                case MouseBindingCommandType.PreviousProfile:
+                    SwitchProfile(true);
+                    break;
+                case MouseBindingCommandType.Play:
+                    _audioSession.CurrentAudioSource?.PlayTrackAsync();
+                    break;
+                case MouseBindingCommandType.Pause:
+                    _audioSession.CurrentAudioSource?.PauseTrackAsync();
+                    break;
+                case MouseBindingCommandType.NextSong:
+                    _audioSession.CurrentAudioSource?.NextTrackAsync();
+                    break;
+                case MouseBindingCommandType.PreviousSong:
+                    _audioSession.CurrentAudioSource?.PreviousTrackAsync();
+                    break;
+                case MouseBindingCommandType.NextRepeatMode:
+                    break;
+                case MouseBindingCommandType.PreviousRepeatMode:
+                    break;
+                case MouseBindingCommandType.ToggleShuffleMode:
+                    break;
+                case MouseBindingCommandType.VolumeHigher:
+                    break;
+                case MouseBindingCommandType.VolumeLower:
+                    break;
+                case MouseBindingCommandType.OpenAssociatedApp:
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        private void OpenAssociatedApp()
+        {
+            if (SelectedAudioSource == null)
+            {
+                return;
+            }
+
+            var windowPtr = NativeMethods.FindWindow(SelectedAudioSource.WindowClassName, null);
+
+            // Spotify has some weird shenanigans with their windows, doing it like normal
+            // results in the wrong window handle being returned.
+            if (SelectedAudioSource.Name == "Spotify")
+            {
+                var spotifyProcesses = Process.GetProcessesByName("spotify");
+                var title = spotifyProcesses.FirstOrDefault(x => !string.IsNullOrEmpty(x.MainWindowTitle))?.MainWindowTitle;
+                windowPtr = NativeMethods.FindWindow(null, title);
+            }
+
+            if (windowPtr == IntPtr.Zero)
+            {
+                Logger.Warn("Could not find the associated window to open with double click.");
+                return;
+            }
+
+            if (NativeMethods.IsIconic(windowPtr))
+            {
+                NativeMethods.ShowWindow(windowPtr, 9);
+            }
+
+            NativeMethods.SetForegroundWindow(windowPtr);
+        }
+
+        private void SwitchProfile(bool previous = false)
+        {
+            var index = Array.FindIndex(_appSettings.Profiles.ToArray(), x => x.Name == _appSettings.CurrentProfile.Name);
+            index = previous ? index - 1 : index + 1;
+
+            _appSettings.SelectProfile(_appSettings.Profiles.ElementAt(index).Name);
+        }
+
+        private async Task NextSong()
+        {
+            await _audioSession.CurrentAudioSource?.NextTrackAsync();
+            await _audioSession.CurrentAudioSource?.PreviousTrackAsync();
+            await _audioSession.CurrentAudioSource?.PlayTrackAsync();
+            await _audioSession.CurrentAudioSource?.PauseTrackAsync();
+        }
+    }
+}

--- a/src/AudioBand/UI/Toolbar/MouseBindingsViewModel.cs
+++ b/src/AudioBand/UI/Toolbar/MouseBindingsViewModel.cs
@@ -239,6 +239,20 @@ namespace AudioBand.UI
             {
                 var spotifyProcesses = Process.GetProcessesByName("spotify");
                 var title = spotifyProcesses.FirstOrDefault(x => !string.IsNullOrEmpty(x.MainWindowTitle))?.MainWindowTitle;
+
+                if (string.IsNullOrEmpty(title))
+                {
+                    try
+                    {
+                        var path = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+                        Process.Start($"{path}/Spotify/Spotify.exe");
+                    }
+                    catch (Exception)
+                    {
+                        Logger.Debug("Failed to open Spotify through path.");
+                    }
+                }
+
                 windowPtr = NativeMethods.FindWindow(null, title);
             }
 

--- a/src/AudioBand/UI/Toolbar/SettingsWindow.xaml
+++ b/src/AudioBand/UI/Toolbar/SettingsWindow.xaml
@@ -101,6 +101,19 @@
                             <TextBlock Text="{StaticResource GlobalSettingsTab}" />
                         </StackPanel>
                     </RadioButton>
+                    <RadioButton Command="{Binding SelectViewModelCommand}"
+                        CommandParameter="{Binding ViewModels.MouseBindingsViewModel}"
+                        GroupName="nav"
+                        Style="{StaticResource NavigationPaneRadioButton}">
+                        <StackPanel Orientation="Horizontal">
+                            <StackPanel Width="18" Height="18" >
+                                <TextBlock HorizontalAlignment="Left" VerticalAlignment="Center" FontFamily="Segoe MDL2 Assets"
+                                           FontSize="18" Text="&#xE962;">
+                                </TextBlock>
+                            </StackPanel>
+                            <TextBlock Padding="14,0,0,0" Text="{StaticResource MouseBindingsTab}" />
+                        </StackPanel>
+                    </RadioButton>
                     <!--Profile Settings expander-->
                     <Expander Style="{StaticResource NavigationPaneExpander}" IsExpanded="False">
                         <Expander.Header>
@@ -455,6 +468,9 @@
                             <DataTrigger Binding="{Binding SelectedViewModel, Converter={x:Static audioband:Converters.ObjectToType}}" Value="{x:Type audioband:GlobalSettingsViewModel}">
                                 <Setter Property="Text" Value="{StaticResource GlobalSettingsTab}" />
                             </DataTrigger>
+                            <DataTrigger Binding="{Binding SelectedViewModel, Converter={x:Static audioband:Converters.ObjectToType}}" Value="{x:Type audioband:MouseBindingsViewModel}">
+                                <Setter Property="Text" Value="{StaticResource MouseBindingsTab}" />
+                            </DataTrigger>
                             <DataTrigger Binding="{Binding SelectedViewModel, Converter={x:Static audioband:Converters.ObjectToType}}" Value="{x:Type audioband:AlbumArtViewModel}">
                                 <Setter Property="Text" Value="{StaticResource AlbumArtTab}" />
                             </DataTrigger>
@@ -508,6 +524,7 @@
                         <ResourceDictionary>
                             <ResourceDictionary.MergedDictionaries>
                                 <audioband:SharedDictionary Source="GlobalSettingsView.xaml" />
+                                <audioband:SharedDictionary Source="MouseBindingsView.xaml" />
                                 <audioband:SharedDictionary Source="GeneralSettingsView.xaml" />
                                 <audioband:SharedDictionary Source="../AlbumArt/AlbumArtSettingsView.xaml" />
                                 <audioband:SharedDictionary Source="../AlbumArt/AlbumArtPopupSettingsView.xaml" />

--- a/src/AudioBand/UI/ViewModel/IViewModelContainer.cs
+++ b/src/AudioBand/UI/ViewModel/IViewModelContainer.cs
@@ -11,6 +11,11 @@
         GlobalSettingsViewModel GlobalSettingsViewModel { get; }
 
         /// <summary>
+        /// Gets the viewmodel for Mouse Bindings.
+        /// </summary>
+        public MouseBindingsViewModel MouseBindingsViewModel { get; }
+
+        /// <summary>
         /// Gets the viewmodel for audioband toolbar.
         /// </summary>
         GeneralSettingsViewModel GeneralSettingsViewModel { get; }

--- a/src/AudioBand/UI/ViewModel/ViewModelContainer.cs
+++ b/src/AudioBand/UI/ViewModel/ViewModelContainer.cs
@@ -9,6 +9,7 @@
         /// Initializes a new instance of the <see cref="ViewModelContainer"/> class.
         /// </summary>
         /// <param name="globalSettingsViewModel">Global Audioband settings view model.</param>
+        /// <param name="mouseBindingsViewModel">Mouse bindings view model.</param>
         /// <param name="generalSettingsViewModel">Audioband view model.</param>
         /// <param name="albumArtPopupViewModel">Album art popup view model.</param>
         /// <param name="albumArtViewModel">Album art view model.</param>
@@ -24,6 +25,7 @@
         /// <param name="audioSourceSettingsViewModel">Audio source settings view model.</param>
         public ViewModelContainer(
             GlobalSettingsViewModel globalSettingsViewModel,
+            MouseBindingsViewModel mouseBindingsViewModel,
             GeneralSettingsViewModel generalSettingsViewModel,
             AlbumArtPopupViewModel albumArtPopupViewModel,
             AlbumArtViewModel albumArtViewModel,
@@ -39,6 +41,7 @@
             AudioSourceSettingsViewModel audioSourceSettingsViewModel)
         {
             GlobalSettingsViewModel = globalSettingsViewModel;
+            MouseBindingsViewModel = mouseBindingsViewModel;
             GeneralSettingsViewModel = generalSettingsViewModel;
             AlbumArtPopupViewModel = albumArtPopupViewModel;
             AlbumArtViewModel = albumArtViewModel;
@@ -56,6 +59,9 @@
 
         /// <inheritdoc />
         public GlobalSettingsViewModel GlobalSettingsViewModel { get; }
+
+        /// <inheritdoc />
+        public MouseBindingsViewModel MouseBindingsViewModel { get; }
 
         /// <inheritdoc />
         public GeneralSettingsViewModel GeneralSettingsViewModel { get; }


### PR DESCRIPTION
## Summary
Implement Customizable MouseBindings. The UI is super bare bones, but in lieu of #44 and saving work that will later be undone anyway, I'll keep it like this for a while.

You can customize whether you should press ctrl/shift/alt/windows key while doing any mouse movement.
You can also have multiple ways of doing separate commands. No limitations.  
If you want to see more Command options feel free to open an issue or suggest it in our Discord Server.

What it currently looks like:
![image](https://user-images.githubusercontent.com/35664724/163604894-a6451d56-64bf-4c4b-963d-3e0e8281333d.png)


## Linked Issues
Resolves #35
Resolves #7 