### PR TITLE
Rename ProgressBarThumbColorDescription

### DIFF
--- a/src/AudioBand/UI/Resources/Strings.xaml
+++ b/src/AudioBand/UI/Resources/Strings.xaml
@@ -185,7 +185,7 @@ Using style and color : {*artist:#a9a9a9}</sys:String>
     <sys:String x:Key="ProgressBarBackgroundColorDescription">Background color</sys:String>
     <sys:String x:Key="ProgressBarHoverColorDescription">Background color when hovered</sys:String>
     <sys:String x:Key="ProgressBarThumbBorderColorDescription">Thumb's border color</sys:String>
-    <sys:String x:Key="ProgressBarThumbColorDescription">Thumb's border color</sys:String>
+    <sys:String x:Key="ProgressBarThumbColorDescription">Thumb color</sys:String>
 
     <!--  Album art settings text  -->
     <sys:String x:Key="AlbumArtPlaceholderSectionText">Image</sys:String>

--- a/src/AudioBand/UI/TrackProgress/ProgressBarSettingsView.xaml
+++ b/src/AudioBand/UI/TrackProgress/ProgressBarSettingsView.xaml
@@ -42,13 +42,13 @@
                          Width="610"
                          Style="{StaticResource ArrangementGridStyle}">
                 <audioband:ColorPicker Margin="0,5,5,0"
-                                Title="{StaticResource ProgressBarThumbBorderColorDescription}"
-                                DialogService="{Binding DialogService}"
-                                Color="{Binding ThumbBorderColor}" />
-                <audioband:ColorPicker Margin="0,5,5,0"
                                 Title="{StaticResource ProgressBarThumbColorDescription}"
                                 DialogService="{Binding DialogService}"
                                 Color="{Binding ProgressBarThumbColor}" />
+                <audioband:ColorPicker Margin="0,5,5,0"
+                                Title="{StaticResource ProgressBarThumbBorderColorDescription}"
+                                DialogService="{Binding DialogService}"
+                                Color="{Binding ThumbBorderColor}" />
             </UniformGrid>
             <TextBlock Margin="{StaticResource SectionMargin}"
                        Style="{StaticResource TitleTextBlock}"


### PR DESCRIPTION
## Summary
Changes ProgressBarThumbColorDescription from "Thumb's border color" to "Thumb color"
## Checklist
- [ ] Tests passed
- [ ] Changes validated (manually or automated)
- [ ] Closes / Fixes ProgressBarThumbColorDescription

## Additional details / comments
Swaped the ThumbBorderolor and ThumbColor around. (Ignore the commit name, it should be "Swap ProgressBar Thumb color and Thumb border color")
## Manual test steps (if applicable)