### PR TITLE
Add support for MS App version of Spotify

### DIFF
--- a/src/AudioBand/UI/Toolbar/MouseBindingsViewModel.cs
+++ b/src/AudioBand/UI/Toolbar/MouseBindingsViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Windows.Input;
 using AudioBand.AudioSource;
@@ -304,11 +305,12 @@ namespace AudioBand.UI
                     try
                     {
                         var path = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-                        Process.Start($"{path}/Spotify/Spotify.exe");
+                        var exe = $"{path}/Spotify/Spotify.exe";
+                        Process.Start(File.Exists(exe) ? exe : "spotify://");
                     }
                     catch (Exception)
                     {
-                        Logger.Debug("Failed to open Spotify through path.");
+                        Logger.Debug("Failed to open Spotify through path or protocol.");
                     }
                 }
 


### PR DESCRIPTION
## Summary
Adds support for the Microsft Store App version of Spotify to be able to be opened by double clicking. In the same way, as the classic Win32 Spotify does. To achieve that, Spotify's app protocol is used `spotify://`. Also, the existing opening method of the regular exe version stays intact.

## Related Issue
#82, https://github.com/AudioBand/AudioBand/issues/51#issuecomment-1222491676

## Checklist
- [x] Project Builds & Tests pass
- [x] These changes were tested out thoroughly

## Manual test steps
Had to make sure both versions of the installation worked. Spotify installed via classic Win32 setup installer and App from Microsoft Store. Therefore to test it, both need to be installed **one by one** (**not** at the same time). Then double-clicking on Audio Band in the taskbar opens Spotify each time, without an issue.