### PR TITLE
Add gradient progress bar

### DIFF
--- a/src/AudioBand/UI/PlaybackControls/VolumeButtonSettingsView.xaml
+++ b/src/AudioBand/UI/PlaybackControls/VolumeButtonSettingsView.xaml
@@ -24,7 +24,7 @@
                        Text="{StaticResource PopupColorSectionText}" />
             <UniformGrid Columns="2"
                          Rows="1"
-                         Width="600"
+                         Width="510"
                          Style="{StaticResource ArrangementGridStyle}">
                 <ui:ColorPicker Margin="0,5,5,0"
                                 Title="{StaticResource VolumeBarForegroundLabelText}"
@@ -43,7 +43,7 @@
                             Color="{Binding PopupBackgroundColor}" />
             <UniformGrid Columns="2"
                          Rows="1"
-                         Width="600"
+                         Width="510"
                          Style="{StaticResource ArrangementGridStyle}">
                 <ui:ColorPicker Margin="0,5,5,0"
                                 Title="{StaticResource VolumeBarThumbColorDescription}"

--- a/src/AudioBand/UI/TrackProgress/ProgressBarSettingsView.xaml
+++ b/src/AudioBand/UI/TrackProgress/ProgressBarSettingsView.xaml
@@ -20,7 +20,7 @@
                        Text="{StaticResource ProgressBarColorsSectionText}" />
             <UniformGrid Columns="2"
                          Rows="1"
-                         Width="610"
+                         Width="510"
                          Style="{StaticResource ArrangementGridStyle}">
                 <audioband:ColorPicker Margin="0,5,5,0"
                                        Title="{StaticResource ProgressBarForegroundColorDescription}"
@@ -39,13 +39,13 @@
                                    Color="{Binding HoverColor}" />
             <UniformGrid Columns="2"
                          Rows="1"
-                         Width="610"
+                         Width="510"
                          Style="{StaticResource ArrangementGridStyle}">
                 <audioband:ColorPicker Margin="0,5,5,0"
                                 Title="{StaticResource ProgressBarThumbColorDescription}"
                                 DialogService="{Binding DialogService}"
                                 Color="{Binding ProgressBarThumbColor}" />
-                <audioband:ColorPicker Margin="0,5,5,0"
+                <audioband:ColorPicker Margin="5,5,0,0"
                                 Title="{StaticResource ProgressBarThumbBorderColorDescription}"
                                 DialogService="{Binding DialogService}"
                                 Color="{Binding ThumbBorderColor}" />


### PR DESCRIPTION
## Summary
Changes UI in ProgressBar so that there is a space between buttons as I misplaced the spacing offsetting the Thumb's boarder color UI.

## Checklist
- [x] Project Builds & Tests pass
- [x] UI works properly
