### PR TITLE
Fix profile download crash

### DIFF
--- a/src/AudioBand/GitHubHelper.cs
+++ b/src/AudioBand/GitHubHelper.cs
@@ -172,8 +172,6 @@ namespace AudioBand
 
         private async Task DownloadDirectoryAssetsAsync(IReadOnlyList<RepositoryContent> files, string assetsFolderPath, string assetsUrl)
         {
-            using var client = new WebClient();
-
             if (!Directory.Exists(assetsFolderPath))
             {
                 Directory.CreateDirectory(assetsFolderPath);
@@ -183,7 +181,9 @@ namespace AudioBand
             {
                 if (files[i].Type == ContentType.File)
                 {
-                    client.DownloadFile(new Uri(files[i].DownloadUrl), Path.Combine(assetsFolderPath, files[i].Name));
+                    using var client = new WebClient();
+
+                    client.DownloadFileAsync(new Uri(files[i].DownloadUrl), Path.Combine(assetsFolderPath, files[i].Name));
                 }
                 else if (files[i].Type == ContentType.Dir)
                 {

--- a/src/AudioBand/UI/Popups/PopupService.cs
+++ b/src/AudioBand/UI/Popups/PopupService.cs
@@ -46,7 +46,7 @@ namespace AudioBand.UI
         /// </summary>
         /// <param name="title">The title string key of the popup.</param>
         /// <param name="description">The text to show to the user.</param>
-        /// <param name="duration">The duration to show the popup for (max 60 seconds).</param>
+        /// <param name="duration">The duration to show the popup for (max 180 seconds).</param>
         public void ShowPopup(string title, string description, TimeSpan duration)
         {
             // First one is an edge-case, handled in here separately.

--- a/src/AudioBand/UI/Resources/Strings.xaml
+++ b/src/AudioBand/UI/Resources/Strings.xaml
@@ -221,6 +221,8 @@ Using style and color : {*artist:#a9a9a9}</sys:String>
     <sys:String x:Key="FileCorruptedDescription">It appears that your settings file was corrupted, it was backed up and reset. For more info contact us on GitHub or Discord.</sys:String>
     <sys:String x:Key="LikeButtonUpdateTitle">❤️ Like button is here!</sys:String>
     <sys:String x:Key="LikeButtonUpdateDescription">But, you need to redo Spotify Authentication to make it work. Make sure to update the redirect url to http://localhost/callback. Then go to Spotify Settings, enable 'Force Refresh Authentication' and click Apply.</sys:String>
+    <sys:String x:Key="GitHubApiLimitTitle">Download limit Reached!</sys:String>
+    <sys:String x:Key="GitHubApiLimitDescription">GitHub only allows so many file downloads per hour. Please try again later!</sys:String>
 
     <!--  Profiles  -->
     <sys:String x:Key="NewProfileHelpText">New profile</sys:String>

--- a/src/AudioBand/UI/Toolbar/ProfileRepoViewModel.cs
+++ b/src/AudioBand/UI/Toolbar/ProfileRepoViewModel.cs
@@ -11,6 +11,7 @@ using AudioBand.Messages;
 using AudioBand.Models;
 using AudioBand.Settings;
 using Newtonsoft.Json;
+using Octokit;
 
 namespace AudioBand.UI
 {
@@ -235,6 +236,11 @@ namespace AudioBand.UI
                 communityProfile.IsInstalled = true;
                 communityProfile.IsLatestVersion = true;
                 _messageBus.Publish(ProfilesUpdatedMessage.ProfileCreated);
+            }
+            catch (RateLimitExceededException e)
+            {
+                Logger.Warn("GitHub RateLimit exceeded! Cannot download more profiles for a while");
+                PopupService.Instance.ShowPopup("GitHubApiLimitTitle", "GitHubApiLimitDescription", TimeSpan.FromSeconds(60));
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Summary
Fixes a crash when any profile has a folder in their assets, added a recursive downloader to fix this issue

## Related Issue (if applicable)

## Checklist
- [x] Project Builds & Tests pass
- [x] These changes were tested out thoroughly
